### PR TITLE
fix simplify_alg pols sort bug

### DIFF
--- a/simplify_algorithm.py
+++ b/simplify_algorithm.py
@@ -220,7 +220,7 @@ class SimplifyAlgorithm(QgsProcessingAlgorithm):
                     s_geom_parts = s_geom.asPolygon() # Extract the outer and inner rings in a list
                     # Recreate independant Polygon for each part
                     s_geom_pols = [QgsGeometry.fromPolygonXY([s_geom_part]) for s_geom_part in s_geom_parts ]
-                    s_geom_pols.sort(key=polygon_area())  # Sort polygon by ascending area size
+                    s_geom_pols.sort(key=polygon_area)  # Sort polygon by ascending area size
                     s_geom_outer = s_geom_pols.pop()  # extract the outer ring
                     while s_geom_pols:
                         # Extract each inner ring and test if located inside the polygon in construction


### PR DESCRIPTION
key in `list.sort(cmp=None, key=None, reverse=False)` does not need a '()'.    
The QGIS reports is as follows:
```
QGIS版本：3.18.1-Zürich
QGIS代码版本：202f1bf7e5
Qt版本：5.11.2
GDAL版本：3.1.4
GEOS版本：3.8.1-CAPI-1.13.3
PROJ版本：Rel. 6.3.2, May 1st, 2020
正在处理算法…
正在启动“Simplify”算法…
输入参数：
{ 'INPUT' : 'D:/downloads/new/UIA_World_Countries_Boundaries-shp (2)/World_Countries__Generalized_.shp', 'OUTPUT' : 'TEMPORARY_OUTPUT', 'TOLERANCE' : 1, 'VERBOSE' : True }

Start normalizing input layer
结果：{'OUTPUT': 'output_d49f3211_5f7c_4571_97d4_6eb7e1adfa0c'}
End normalizing input layer
Traceback (most recent call last):
File "C:/Users/beiyu/AppData/Roaming/QGIS/QGIS3\profiles\default/python/plugins\geo_sim_processing\simplify_algorithm.py", line 223, in processAlgorithm
s_geom_pols.sort(key=polygon_area()) # Sort polygon by ascending area size
TypeError: polygon_area() missing 1 required positional argument: 'pol'

执行0.27秒后失败

载入结果图层
算法“Simplify”执行已完成
```

So I remove the '()' in simplify_algorithm.py.    
```python
s_geom_pols.sort(key=polygon_area) # Sort polygon by ascending area size
```